### PR TITLE
Added Calendar Selection

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -18,6 +18,14 @@
   thesis: Mercato elettrico e mining Bitcoin
   thesis_link: https://github.com/simonecolombo/thesis-scolombo
 
+  - name: Stefano Fedeli
+    role: Student @ Politecnico di Milano
+    social_num: 2
+    social_1: fab fa-linkedin-in
+    social_1_link: https://www.linkedin.com/in/stefano-f-676165127/
+    social_2: fab fa-github
+    social_2_link: https://github.com/principesayan
+
 - name: Federico Panisi
   role: Legal Analyst
   social_num: 3
@@ -31,16 +39,16 @@
   affiliation_1: Juris Doctor, Università Cattolica del Sacro Cuore - Milan
   affiliation_2: Ph.D. candidate @ Università degli Studi di Brescia
   affiliation_3: SPILS candidate @ Stanford University
-    
+
 - name: Marcello Pichini
   role: Market Data Specialist
   social_num: 1
   social_1: fab fa-github
   social_1_link: https://github.com/mpichini1
   affiliation_rows: 3
-  affiliation_1: <br> 
+  affiliation_1: <br>
   affiliation_2: <br>
-  affiliation_3:  
+  affiliation_3:
 
 - name: Nicholas Sollazzo
   role: ICT Analyst

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -18,14 +18,6 @@
   thesis: Mercato elettrico e mining Bitcoin
   thesis_link: https://github.com/simonecolombo/thesis-scolombo
 
-  - name: Stefano Fedeli
-    role: Student @ Politecnico di Milano
-    social_num: 2
-    social_1: fab fa-linkedin-in
-    social_1_link: https://www.linkedin.com/in/stefano-f-676165127/
-    social_2: fab fa-github
-    social_2_link: https://github.com/principesayan
-
 - name: Federico Panisi
   role: Legal Analyst
   social_num: 3

--- a/_includes/ots-tutorial.html
+++ b/_includes/ots-tutorial.html
@@ -132,6 +132,17 @@
                             <textarea type="text" id="stamp-filename" name="stamp-filename" class="form-control"
                                 rows="1" cols="64">datafile.ext.ots</textarea>
                         </div>
+                        <div class="form-group">
+                            <label for="stamp-filename">OTS Calendar selection</label><br>
+                            <input type="checkbox" id="stamp-calendar" name="stamp-calendar" value="https://btc.ots.dgi.io">
+                              <a href="https://btc.ots.dgi.io">Dgi Server</a>
+                            <input type="checkbox" id="stamp-calendar" name="stamp-calendar" value="https://alice.btc.calendar.opentimestamps.org">
+                            <a href="https://alice.btc.calendar.opentimestamps.org">alice.opentimestamps Server</a>
+                            <input type="checkbox" id="stamp-calendar" name="stamp-calendar" value="https://bob.btc.calendar.opentimestamps.org">
+                              <a href="https://bob.btc.calendar.opentimestamps.org">bob.opentimestamps Server</a>
+                            <input type="checkbox" id="stamp-calendar" name="stamp-calendar" value="https://finney.calendar.eternitywall.com">
+                              <a href="https://finney.calendar.eternitywall.com">finney.eternitywall Server </a>
+                        </div>
                         <br>
                         <div class="col-lg-12 text-center">
                             <button class="btn btn-primary" id="btn-stamp">SUBMIT HASH</button>
@@ -264,6 +275,17 @@
                             <textarea type="text" id="upgrade-filename" name="upgrade-filename" class="form-control"
                                 rows="1" cols="64">datafile.ext.upgraded.ots</textarea>
                         </div>
+                        <div class="form-group">
+                            <label for="stamp-filename">OTS Calendar selection</label><br>
+                            <input type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://btc.ots.dgi.io">
+                              <a href="https://btc.ots.dgi.io">Dgi Server</a>
+                            <input type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://alice.btc.calendar.opentimestamps.org">
+                              <a href="https://alice.btc.calendar.opentimestamps.org">alice.opentimestamps Server</a>
+                            <input type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://bob.btc.calendar.opentimestamps.org">
+                              <a href="https://bob.btc.calendar.opentimestamps.org">bob.opentimestamps Server</a>
+                            <input type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://finney.calendar.eternitywall.com">
+                              <a href="https://finney.calendar.eternitywall.com">finney.eternitywall Server </a>
+                        </div>
                         <br>
                         <div class="col-lg-12 text-center">
                             <button class="btn btn-primary" id="btn-upgrade">UPGRADE OTS RECEIPT/PROOF</button>
@@ -322,6 +344,17 @@
                             <label for="verify-filename">Filename for the upgraded OTS proof (if any)</label>
                             <textarea type="text" id="verify-filename" name="verify-filename" class="form-control"
                                 rows="1" cols="64">datafile.ext.upgraded.ots</textarea>
+                        </div>
+                        <div class="form-group">
+                            <label for="stamp-filename">OTS Calendar selection</label><br>
+                            <input type="checkbox" id="verify-calendar" name="verify-calendar" value="https://btc.ots.dgi.io">
+                              <a href="https://btc.ots.dgi.io">Dgi Server</a>
+                            <input type="checkbox" id="verify-calendar" name="verify-calendar" value="https://alice.btc.calendar.opentimestamps.org">
+                              <a href="https://alice.btc.calendar.opentimestamps.org">alice.opentimestamps Server</a>
+                            <input type="checkbox" id="verify-calendar" name="verify-calendar" value="https://bob.btc.calendar.opentimestamps.org">
+                              <a href="https://bob.btc.calendar.opentimestamps.org">bob.opentimestamps Server</a>
+                            <input type="checkbox" id="verify-calendar" name="verify-calendar" value="https://finney.calendar.eternitywall.com">
+                              <a href="https://finney.calendar.eternitywall.com">finney.eternitywall Server </a>
                         </div>
                         <br>
                         <div class="col-lg-12 text-center">

--- a/_includes/ots-tutorial.html
+++ b/_includes/ots-tutorial.html
@@ -275,18 +275,6 @@
                             <textarea type="text" id="upgrade-filename" name="upgrade-filename" class="form-control"
                                 rows="1" cols="64">datafile.ext.upgraded.ots</textarea>
                         </div>
-                        <div class="form-group">
-                            <label for="stamp-filename">OTS Calendar selection</label><br>
-                            <input class="col-sm" type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://btc.ots.dgi.io">
-                              <a href="https://btc.ots.dgi.io">Btc (dgi.io)</a><br>
-                            <input class="col-sm" type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://alice.btc.calendar.opentimestamps.org">
-                              <a href="https://alice.btc.calendar.opentimestamps.org">Alice (opentimestamps)</a><br>
-                            <input class="col-sm" type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://bob.btc.calendar.opentimestamps.org">
-                              <a href="https://bob.btc.calendar.opentimestamps.org">Bob (opentimestamps)</a><br>
-                            <input class="col-sm" type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://finney.calendar.eternitywall.com">
-                              <a href="https://finney.calendar.eternitywall.com">Finney (eternitywall)</a><br>
-                        </div>
-                        <br>
                         <div class="col-lg-12 text-center">
                             <button class="btn btn-primary" id="btn-upgrade">UPGRADE OTS RECEIPT/PROOF</button>
                         </div>

--- a/_includes/ots-tutorial.html
+++ b/_includes/ots-tutorial.html
@@ -88,7 +88,7 @@
                 <hr class="primary">
             </div>
             <p class="text-muted">
-                Submit the hash to multiple OpenTimestamps
+                Submit the hash to a selected set of OpenTimestamps
                 public calendar servers
                 (e.g. <a href="https://btc.ots.dgi.io">btc.ots.dgi.io</a>)
                 for <em>attestation</em> of its existence (timestamp)
@@ -133,15 +133,15 @@
                                 rows="1" cols="64">datafile.ext.ots</textarea>
                         </div>
                         <div class="form-group">
-                            <label for="stamp-filename">OTS Calendar selection</label><br>
-                            <input type="checkbox" id="stamp-calendar" name="stamp-calendar" value="https://btc.ots.dgi.io">
-                              <a href="https://btc.ots.dgi.io">Dgi Server</a>
-                            <input type="checkbox" id="stamp-calendar" name="stamp-calendar" value="https://alice.btc.calendar.opentimestamps.org">
-                            <a href="https://alice.btc.calendar.opentimestamps.org">alice.opentimestamps Server</a>
-                            <input type="checkbox" id="stamp-calendar" name="stamp-calendar" value="https://bob.btc.calendar.opentimestamps.org">
-                              <a href="https://bob.btc.calendar.opentimestamps.org">bob.opentimestamps Server</a>
-                            <input type="checkbox" id="stamp-calendar" name="stamp-calendar" value="https://finney.calendar.eternitywall.com">
-                              <a href="https://finney.calendar.eternitywall.com">finney.eternitywall Server </a>
+                          <label for="stamp-filename">OTS Calendar selection</label><br>
+                          <input type="checkbox" id="stamp-calendar" name="stamp-calendar" value="https://btc.ots.dgi.io">
+                          <a href="https://btc.ots.dgi.io">Btc (dgi.io)</a><br>
+                          <input  type="checkbox" id="stamp-calendar" name="stamp-calendar" value="https://alice.btc.calendar.opentimestamps.org">
+                          <a href="https://alice.btc.calendar.opentimestamps.org">Alice (opentimestamps)</a><br>
+                          <input type="checkbox" id="stamp-calendar" name="stamp-calendar" value="https://bob.btc.calendar.opentimestamps.org">
+                          <a href="https://bob.btc.calendar.opentimestamps.org">Bob (opentimestamps)</a><br>
+                          <input type="checkbox" id="stamp-calendar" name="stamp-calendar" value="https://finney.calendar.eternitywall.com">
+                          <a href="https://finney.calendar.eternitywall.com">Finney (eternitywall)</a><br>
                         </div>
                         <br>
                         <div class="col-lg-12 text-center">
@@ -247,7 +247,7 @@
             </div>
             <p class="text-muted">
                 Attempt the upgrade of the OTS receipt/proof with attestations
-                that might be available from the OpenTimestamps calendars;
+                that might be available from the selected OpenTimestamps calendars;
                 internet connectivity is required.
                 <br>
                 To be upgraded to proof status, incomplete receipts require the
@@ -277,14 +277,14 @@
                         </div>
                         <div class="form-group">
                             <label for="stamp-filename">OTS Calendar selection</label><br>
-                            <input type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://btc.ots.dgi.io">
-                              <a href="https://btc.ots.dgi.io">Dgi Server</a>
-                            <input type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://alice.btc.calendar.opentimestamps.org">
-                              <a href="https://alice.btc.calendar.opentimestamps.org">alice.opentimestamps Server</a>
-                            <input type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://bob.btc.calendar.opentimestamps.org">
-                              <a href="https://bob.btc.calendar.opentimestamps.org">bob.opentimestamps Server</a>
-                            <input type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://finney.calendar.eternitywall.com">
-                              <a href="https://finney.calendar.eternitywall.com">finney.eternitywall Server </a>
+                            <input class="col-sm" type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://btc.ots.dgi.io">
+                              <a href="https://btc.ots.dgi.io">Btc (dgi.io)</a><br>
+                            <input class="col-sm" type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://alice.btc.calendar.opentimestamps.org">
+                              <a href="https://alice.btc.calendar.opentimestamps.org">Alice (opentimestamps)</a><br>
+                            <input class="col-sm" type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://bob.btc.calendar.opentimestamps.org">
+                              <a href="https://bob.btc.calendar.opentimestamps.org">Bob (opentimestamps)</a><br>
+                            <input class="col-sm" type="checkbox" id="upgrade-calendar" name="upgrade-calendar" value="https://finney.calendar.eternitywall.com">
+                              <a href="https://finney.calendar.eternitywall.com">Finney (eternitywall)</a><br>
                         </div>
                         <br>
                         <div class="col-lg-12 text-center">
@@ -327,7 +327,7 @@
                 filesystem, this page relies on public block-explorers
                 for verification.
                 <br>
-                First an upgraded proof is obtained from the calendar
+                First an upgraded proof is obtained from the selected calendar
                 servers if available (as in the step above, performed
                 also here to ensure updated informations),
                 then the receipt/proof status is displayed below.
@@ -345,16 +345,16 @@
                             <textarea type="text" id="verify-filename" name="verify-filename" class="form-control"
                                 rows="1" cols="64">datafile.ext.upgraded.ots</textarea>
                         </div>
-                        <div class="form-group">
+                        <div class="form-group row">
                             <label for="stamp-filename">OTS Calendar selection</label><br>
-                            <input type="checkbox" id="verify-calendar" name="verify-calendar" value="https://btc.ots.dgi.io">
-                              <a href="https://btc.ots.dgi.io">Dgi Server</a>
-                            <input type="checkbox" id="verify-calendar" name="verify-calendar" value="https://alice.btc.calendar.opentimestamps.org">
-                              <a href="https://alice.btc.calendar.opentimestamps.org">alice.opentimestamps Server</a>
-                            <input type="checkbox" id="verify-calendar" name="verify-calendar" value="https://bob.btc.calendar.opentimestamps.org">
-                              <a href="https://bob.btc.calendar.opentimestamps.org">bob.opentimestamps Server</a>
-                            <input type="checkbox" id="verify-calendar" name="verify-calendar" value="https://finney.calendar.eternitywall.com">
-                              <a href="https://finney.calendar.eternitywall.com">finney.eternitywall Server </a>
+                            <input  class="col-sm" type="checkbox" id="verify-calendar" name="verify-calendar" value="https://btc.ots.dgi.io">
+                              <a href="https://btc.ots.dgi.io">Btc (dgi.io)</a><br>
+                            <input class="col-sm" type="checkbox" id="verify-calendar" name="verify-calendar" value="https://alice.btc.calendar.opentimestamps.org">
+                              <a href="https://alice.btc.calendar.opentimestamps.org">Alice (opentimestamps)</a><br>
+                            <input class="col-sm" type="checkbox" id="verify-calendar" name="verify-calendar" value="https://bob.btc.calendar.opentimestamps.org">
+                              <a href="https://bob.btc.calendar.opentimestamps.org">Bob (opentimestamps)</a><br>
+                            <input class="col-sm" type="checkbox" id="verify-calendar" name="verify-calendar" value="https://finney.calendar.eternitywall.com">
+                              <a href="https://finney.calendar.eternitywall.com">Finney (eternitywall)</a><br>
                         </div>
                         <br>
                         <div class="col-lg-12 text-center">

--- a/ots/javascripts/tools/tools.js
+++ b/ots/javascripts/tools/tools.js
@@ -62,10 +62,15 @@ $("#btn-stamp").click(function(event) {
     const hashValue = $("#stamp-hashValue").val()
     const hashData = hexToBytes(hashValue)
     const detachedOriginal = OpenTimestamps.DetachedTimestampFile.fromHash(op, hashData)
+    var calendars = []
+  	$("input:checkbox[name='stamp-calendar']:checked").each(function(){
+  		calendars.push($(this).val())
+  	})
+    const param = { calendars: calendars }
 
     const filename = $("#stamp-filename").val()
 
-    OpenTimestamps.stamp(detachedOriginal).then( () => {
+    OpenTimestamps.stamp(detachedOriginal,param).then( () => {
         const byteots = detachedOriginal.serializeToBytes()
         const hexots = bytesToHex(byteots)
         $("#stamp-output").val(hexots)
@@ -160,10 +165,16 @@ $("#btn-upgrade").click(function(event) {
     const hashValue = bytesToHex(digest)
     $("#upgrade-hashValue").val(hashValue)
 
+    var calendars = []
+    $("input:checkbox[name='upgrade-calendar']:checked").each(function(){
+      calendars.push($(this).val())
+    })
+    const param = { calendars: calendars }
+
     const filename = $("#upgrade-filename").val()
     $("#verify-filename").val(filename)
 
-    OpenTimestamps.upgrade(detachedStamped).then( (changed)=>{
+    OpenTimestamps.upgrade(detachedStamped,param).then( (changed)=>{
         const timestampBytes = detachedStamped.serializeToBytes()
         const hexots = bytesToHex(timestampBytes)
         if (changed === true) {
@@ -200,10 +211,16 @@ $("#btn-verify").click(function(event) {
     const hashValue = bytesToHex(digest)
     $("#verify-hashValue").val(hashValue)
 
+    var calendars = []
+    $("input:checkbox[name='verify-calendar']:checked").each(function(){
+      calendars.push($(this).val())
+    })
+    const param = { calendars: calendars }
+
     const filename = $("#verify-filename").val()
     var outputText = ""
 
-    OpenTimestamps.upgrade(detachedStamped).then( (changed)=>{
+    OpenTimestamps.upgrade(detachedStamped,param).then( (changed)=>{
         const timestampBytes = detachedStamped.serializeToBytes()
         hexots = bytesToHex(timestampBytes)
         if (changed === true) {

--- a/ots/javascripts/tools/tools.js
+++ b/ots/javascripts/tools/tools.js
@@ -165,9 +165,12 @@ $("#btn-upgrade").click(function(event) {
     const hashValue = bytesToHex(digest)
     $("#upgrade-hashValue").val(hashValue)
 
+    const info = OpenTimestamps.info(detachedStamped)
     var calendars = []
-    $("input:checkbox[name='upgrade-calendar']:checked").each(function(){
-      calendars.push($(this).val())
+    calendarsList.forEach(function(item,index){
+      if(info.includes(item)){
+        calendars.push(item);
+      }
     })
     const param = { calendars: calendars }
 


### PR DESCRIPTION
Added a new functionality in the OTS Tutorial Section:

- Users can select the set of calendar servers to use during a specific action in the tutorial. No selection, an empty set, redirect to the [default set](https://opentimestamps.org/docs/javascript-opentimestamps/calendar.js.html#line172) of the library.

